### PR TITLE
api - fix wrong post date

### DIFF
--- a/api.js
+++ b/api.js
@@ -88,7 +88,7 @@ module.exports = {
 				tags: utils.getTags(post.caption),
 				mentions: utils.getMentions(post.caption),
 				description: post.caption,
-				date: new Date(post.date)
+				date: new Date(parseInt(post.date) * 1000)
 			});
 		});
 		next(this);


### PR DESCRIPTION
Post year always 1970

Example: for instagram user **tuan** 
https://www.instagram.com/p/QmeU/?taken-by=tuan

![2017-09-26_154953](https://user-images.githubusercontent.com/17564259/30851294-696d857c-a2d2-11e7-8ae7-4be24d7241ce.png)

Before fix:
![2017-09-26_154522](https://user-images.githubusercontent.com/17564259/30851108-d43e6cb4-a2d1-11e7-8280-c233580c7cfd.png)

After fix:
![2017-09-26_154557](https://user-images.githubusercontent.com/17564259/30851119-d9e52b9e-a2d1-11e7-9ee8-76d60a7b389a.png)


